### PR TITLE
Update version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See the [online documentation](https://hexdocs.pm/nimble_csv) for more informati
 
         ```elixir
         def deps do
-          [{:nimble_csv, "~> 0.6"}]
+          [{:nimble_csv, "~> 0.7"}]
         end
         ```
 


### PR DESCRIPTION
One-character fix, the README should point users to the latest release (0.7).