### PR TITLE
conform to Elixir v. Erlang/OTP combinations suggested by José Valim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
           - elixir: 1.6.6
             otp: 19.3.6.13
           - elixir: 1.7.4
-            otp: 21.3.8.17
+            otp: 19.3.6.13
           - elixir: 1.8.2
-            otp: 21.3.8.17
+            otp: 20.3.8.26
           - elixir: 1.9.4
-            otp: 21.3.8.17
+            otp: 20.3.8.26
           - elixir: 1.10.4
-            otp: 21.3.8.17
+            otp: 21.3.8.16
           - elixir: 1.10.4
             otp: 23.0.3
     steps:


### PR DESCRIPTION
> For each Elixir version, add a run with **earliest** supported Erlang/OTP

Related to https://github.com/dashbitco/nimble_csv/pull/50