### PR TITLE
Add config option to escape formulas on dump

### DIFF
--- a/lib/nimble_csv.ex
+++ b/lib/nimble_csv.ex
@@ -300,7 +300,7 @@ defmodule NimbleCSV do
         end
       end
 
-      defmacro maybe_escape_formulas(entry) do
+      defmacrop maybe_escape_formulas(entry) do
         escapes =
           for {keys, value} <- @escape_formula,
               key <- keys do

--- a/lib/nimble_csv.ex
+++ b/lib/nimble_csv.ex
@@ -309,7 +309,8 @@ defmodule NimbleCSV do
             end
           end
 
-         escapes = List.flatten(escapes) ++ quote do: (_ -> [])
+        escapes = List.flatten(escapes) ++ quote do: (_ -> [])
+
         quote do
           case unquote(entry), do: unquote(escapes)
         end

--- a/lib/nimble_csv.ex
+++ b/lib/nimble_csv.ex
@@ -212,14 +212,14 @@ defmodule NimbleCSV do
   and their documentation.
 
   ## CSV Injection
+
   By default, the dumper does not escape values which some clients may interpret
   as formulas or commands. This can result in
-  [CSV injection](https://owasp.org/www-community/attacks/CSV_Injection). There
-  is no universally correct way to handle CSV injections. In some cases, you may
-  want formulas to be preserved: you may want a cell to have a value of
-  `=SUM(...)`. Furthermore, a simple prefix match is used to "detect" formulas,
-  which could result in false-positives. Finally, the only way to escape these
-  values is by materially changing them by prefixing a tab or single quote.
+  [CSV injection](https://owasp.org/www-community/attacks/CSV_Injection).
+  There is no universally correct way to handle CSV injections. In some cases,
+  you may want formulas to be preserved: you may want a cell to have a value of
+  `=SUM(...)`. The only way to escape these values is by materially changing
+  them by prefixing a tab or single quote, which can also lead to false positives.
 
   The `escape_formula` option will add a prefix to any value which has the
   configured prefix (e.g. it will prepend `\t` to any value which begins with

--- a/test/nimble_csv_test.exs
+++ b/test/nimble_csv_test.exs
@@ -3,6 +3,7 @@ defmodule NimbleCSVTest do
 
   alias NimbleCSV.RFC4180, as: CSV
   alias NimbleCSV.Spreadsheet
+  NimbleCSV.define(EscapedDumper, escape_formula: ?', line_separator: "\r\n")
 
   test "parse_string/2 without headers" do
     assert CSV.parse_string("""
@@ -273,6 +274,19 @@ defmodule NimbleCSVTest do
                name\tage
                "doe\tjohn"\t27
                """)
+
+    assert IO.iodata_to_binary(CSV.dump_to_iodata([["name", "age"], ["goku", "=SUM(5,5)"]])) ==
+             """
+             name,age\r\n\
+             goku,\"=SUM(5,5)\"\r\n\
+             """
+
+    assert IO.iodata_to_binary(
+             EscapedDumper.dump_to_iodata([["name", "age"], ["goku", "=SUM(5,5)"]])
+           ) == """
+           name,age\r\n\
+           goku,\"'=SUM(5,5)\"\r\n\
+           """
   end
 
   test "dump_to_stream/1" do

--- a/test/nimble_csv_test.exs
+++ b/test/nimble_csv_test.exs
@@ -3,7 +3,7 @@ defmodule NimbleCSVTest do
 
   alias NimbleCSV.RFC4180, as: CSV
   alias NimbleCSV.Spreadsheet
-  NimbleCSV.define(EscapedDumper, escape_formula: ?', line_separator: "\r\n")
+  NimbleCSV.define(EscapedDumper, escape_formula: {~w(@ + - =), "\'"}, line_separator: "\r\n")
 
   test "parse_string/2 without headers" do
     assert CSV.parse_string("""

--- a/test/nimble_csv_test.exs
+++ b/test/nimble_csv_test.exs
@@ -3,7 +3,7 @@ defmodule NimbleCSVTest do
 
   alias NimbleCSV.RFC4180, as: CSV
   alias NimbleCSV.Spreadsheet
-  NimbleCSV.define(EscapedDumper, escape_formula: {~w(@ + - =), "\'"}, line_separator: "\r\n")
+  NimbleCSV.define(EscapedDumper, escape_formula: %{~w(@ +) => "\'", ~w(- =) => "\t"}, line_separator: "\r\n")
 
   test "parse_string/2 without headers" do
     assert CSV.parse_string("""
@@ -282,10 +282,11 @@ defmodule NimbleCSVTest do
              """
 
     assert IO.iodata_to_binary(
-             EscapedDumper.dump_to_iodata([["name", "age"], ["goku", "=SUM(5,5)"]])
+             EscapedDumper.dump_to_iodata([["name", "age"], ["goku", "=SUM(5,5)"], ["vegeta", "@cmd:4"]])
            ) == """
            name,age\r\n\
-           goku,\"'=SUM(5,5)\"\r\n\
+           goku,\"\t=SUM(5,5)\"\r\n\
+           vegeta,'@cmd:4\r\n\
            """
   end
 


### PR DESCRIPTION
Add `escape_formula` option (defaults nil) which, when set, escapes
potential formulas with the configured value.

I considered making the list of formulas markers configurable, but I
thought being opinionated with respect to this security feature would be
better.

Some details on the general issue at:
http://georgemauer.net/2017/10/07/csv-injection.html