### PR TITLE
Add header option to order columns

### DIFF
--- a/lib/nimble_csv.ex
+++ b/lib/nimble_csv.ex
@@ -601,10 +601,11 @@ defmodule NimbleCSV do
         |> maybe_dump_bom()
       end
 
-      def dump_to_stream(enumerable, _opts \\ []) do
+      def dump_to_stream(enumerable, opts \\ []) do
+        headers = opts |> Keyword.get(:headers, [])
         check = init_dumper()
 
-        enumerable
+        order_headers(enumerable, headers)
         |> Stream.map(&dump(&1, check))
         |> maybe_dump_bom()
       end
@@ -667,12 +668,10 @@ defmodule NimbleCSV do
 
         theader_number =
           Enum.zip(headers, 0..length(headers))
-          |> IO.inspect(label: "theader_number")
           |> Enum.reduce([], fn {key, _value}, list ->
             list ++
               [
                 Enum.find(header_order, {}, fn {thkey, _} ->
-                  IO.inspect(thkey, label: "theader_number")
                   Atom.to_string(key) == thkey
                 end)
               ]
@@ -680,9 +679,7 @@ defmodule NimbleCSV do
 
         body =
           Enum.map(enumerable, fn line_map ->
-            IO.inspect(line_map, label: "line_map")
             for {_key, val} <- theader_number, into: [] do
-              IO.inspect(val, label: "val")
               Enum.at(line_map, val)
             end
           end)

--- a/test/nimble_csv_test.exs
+++ b/test/nimble_csv_test.exs
@@ -250,7 +250,7 @@ defmodule NimbleCSVTest do
   end
 
   test "dump_to_iodata/1" do
-    assert IO.iodata_to_binary(CSV.dump_to_iodata([["name", "age"], ["john", 27]])) == """
+    assert IO.iodata_to_binary(CSV.dump_to_iodata([["name", "age"], ["john", 27]])) |> IO.inspect(label: "result?") == """
            name,age\r\n\
            john,27\r\n\
            """
@@ -296,6 +296,18 @@ defmodule NimbleCSVTest do
            goku,\"\t=SUM(5,5)\"\r\n\
            vegeta,'@cmd:4\r\n\
            """
+
+    assert IO.iodata_to_binary(
+            EscapedDumper.dump_to_iodata([
+              ["name", "age"],
+              ["goku", "=SUM(5,5)"],
+              ["vegeta", "@cmd:4"]
+            ], headers: [:age, :name])
+          ) == """
+          age,name\r\n\
+          \"\t=SUM(5,5)\",goku\r\n\
+          '@cmd:4,vegeta\r\n\
+          """
   end
 
   test "dump_to_stream/1" do

--- a/test/nimble_csv_test.exs
+++ b/test/nimble_csv_test.exs
@@ -340,6 +340,15 @@ defmodule NimbleCSVTest do
                name\tage
                "john\tnick"\t27
                """)
+
+    assert IO.iodata_to_binary(
+              Enum.to_list(Spreadsheet.dump_to_stream([["name", "age"], ["john\tnick", 27]], headers: [:age, :name]))
+            ) ==
+              utf16le_bom() <>
+                utf16le("""
+                age\tname
+                27\t"john\tnick"
+                """)
   end
 
   describe "multiple separators" do


### PR DESCRIPTION
Add headers options to `dump_to_iodata` and `dump_to_stream` function to order the columns

the same option as the CSV lib [CSV.encode/2](https://hexdocs.pm/csv/CSV.html#encode/2)

the motivation was because of migrate from the CSV lib to Nible (because of performance problems) and this option was really useful from the old lib