### PR TITLE
Add generated to newlines_separator macro

### DIFF
--- a/lib/nimble_csv.ex
+++ b/lib/nimble_csv.ex
@@ -483,7 +483,7 @@ defmodule NimbleCSV do
           end)
           |> Kernel.++(quote do: (prefix -> prefix))
 
-        quote do
+        quote generated: true do
           offset = byte_size(var!(line))
           unquote(newlines_offsets)
           case var!(line), do: unquote(newlines_clauses)


### PR DESCRIPTION
The newlines_separator macro causes dialyzer warnings in projects that use NimbleCSV and have dialyzer enabled. This commit adds the generated attribute to the macro to suppress the warnings.

Tested on a project locally to verify it resolves #80 