### PR TITLE
Support Elixir 1.18 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: 1.15.x
-              otp: 24.x
+              elixir: "1.15"
+              otp: "24"
           - pair:
-              elixir: 1.17.x
-              otp: 27.x
+              elixir: "1.18"
+              otp: "27"
             lint: lint
     steps:
       - uses: actions/checkout@v4

--- a/test/nimble_csv_test.exs
+++ b/test/nimble_csv_test.exs
@@ -393,7 +393,10 @@ defmodule NimbleCSVTest do
              """
 
       assert IO.iodata_to_binary(
-               CSVWithUnknownSeparator.dump_to_iodata([["name", "age"], ["john \"nick\" doe", 27]])
+               CSVWithUnknownSeparator.dump_to_iodata([
+                 ["name", "age"],
+                 ["john \"nick\" doe", 27]
+               ])
              ) == """
              name,age
              "john ""nick"" doe",27


### PR DESCRIPTION
List of changes:
- bump max supported Elixir version to 1.18
- code format
- specify versions as strings, not numbers