### PR TITLE
Replace retired ubuntu-20.04 CI runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       MIX_ENV: test
     strategy:


### PR DESCRIPTION
# Description

This PR restores CI, which has not run successfully on any commit since June 2025.

The workflow pins `runs-on: ubuntu-20.04`. GitHub has retired that hosted image, so no runner is ever assigned to the jobs — they stay queued for 24 hours and are then auto-cancelled with zero steps executed. Because the jobs never start, the failures produce no logs and report as "cancelled" rather than "failed", which is why the breakage was easy to miss.

### What it does

- Moved the test job to the `ubuntu-24.04` hosted image.

### Design decisions

- The image is pinned rather than tracking `ubuntu-latest`. The matrix covers OTP 24, whose prebuilt binaries will not exist on future images, so a floating label would reintroduce this exact failure silently on the next image rollout. Happy to switch to `ubuntu-latest` to match nimble_ownership if you prefer.
- The Elixir/OTP matrix is left unchanged. Both pairs have builds published for ubuntu-24.04, so coverage stays identical to what the workflow was meant to provide before it stopped running. This keeps the change independent of the OTP 28 discussion in #89.

### Testing

Verified on a fork before opening this PR: https://github.com/agustin2606/nimble_csv/actions/runs/30027125956

- Both matrix pairs are assigned a runner and finish in under 20 seconds, against 24 hours queued and cancelled today.
- Every step executes: dependency fetch, format check, unused-dependency check, compile with warnings as errors, and the test suite.

One thing worth flagging separately: ubuntu-24.04 emits a deprecation annotation for `actions/checkout@v4` and `actions/cache@v4` being forced onto Node.js 24. It does not fail the build, so it is left out of this change.
